### PR TITLE
[codex] define v1 mission contracts

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,26 @@
+name: Public contracts
+
+on:
+  push:
+    paths:
+      - "platform/contracts/v1/**"
+      - "tests/contracts/**"
+      - ".github/workflows/contracts.yml"
+  pull_request:
+    paths:
+      - "platform/contracts/v1/**"
+      - "tests/contracts/**"
+      - ".github/workflows/contracts.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tests/contracts/requirements.txt
+      - run: pip install -r tests/contracts/requirements.txt
+      - run: python -m unittest discover -s tests/contracts -p "test_*.py" -v

--- a/platform/contracts/v1/README.md
+++ b/platform/contracts/v1/README.md
@@ -1,0 +1,16 @@
+# AgentHub public contracts v1
+
+This directory is the language-neutral contract boundary shared by the
+control plane, runners, adapters, and user interfaces.
+
+## Compatibility rules
+
+- Files in `v1` use JSON Schema Draft 2020-12.
+- Existing required fields and enum values are never removed within v1.
+- Additive optional fields are allowed after the contract tests pass.
+- Breaking changes require a new version directory.
+- Event payloads contain references to large artifacts, never artifact data.
+- The event catalog is authoritative for event names and aggregate ownership.
+
+Domain objects use camelCase to match the public API. Event envelopes use
+snake_case because they are persisted and transported as ledger records.

--- a/platform/contracts/v1/common.schema.json
+++ b/platform/contracts/v1/common.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.agenthub.dev/v1/common.schema.json",
+  "title": "AgentHub v1 common definitions",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "actorRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["human", "service", "agent", "adapter", "runner", "verifier"]
+        },
+        "id": { "$ref": "#/$defs/identifier" },
+        "displayName": { "type": "string", "maxLength": 255 }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "digest"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-fA-F0-9]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/platform/contracts/v1/event-catalog.json
+++ b/platform/contracts/v1/event-catalog.json
@@ -1,0 +1,19 @@
+{
+  "catalogVersion": 1,
+  "events": [
+    { "eventType": "mission.lifecycle.created", "aggregateType": "mission", "payloadRequired": ["contractId", "status"] },
+    { "eventType": "mission.lifecycle.started", "aggregateType": "mission", "payloadRequired": ["planVersion"] },
+    { "eventType": "mission.lifecycle.cancelled", "aggregateType": "mission", "payloadRequired": ["reason"] },
+    { "eventType": "mission.verification.started", "aggregateType": "mission", "payloadRequired": [] },
+    { "eventType": "mission.verification.succeeded", "aggregateType": "mission", "payloadRequired": ["evidenceIds"] },
+    { "eventType": "mission.verification.failed", "aggregateType": "mission", "payloadRequired": ["evidenceIds"] },
+    { "eventType": "mission_contract.version.created", "aggregateType": "mission_contract", "payloadRequired": ["version"] },
+    { "eventType": "work_unit.lifecycle.created", "aggregateType": "work_unit", "payloadRequired": ["missionId", "status"] },
+    { "eventType": "work_unit.lease.granted", "aggregateType": "work_unit", "payloadRequired": ["leaseId", "runnerId", "expiresAt"] },
+    { "eventType": "work_unit.execution.started", "aggregateType": "work_unit", "payloadRequired": ["attempt"] },
+    { "eventType": "work_unit.execution.completed", "aggregateType": "work_unit", "payloadRequired": ["attempt", "artifactRefs"] },
+    { "eventType": "work_unit.execution.failed", "aggregateType": "work_unit", "payloadRequired": ["attempt", "reason"] },
+    { "eventType": "work_unit.verification.completed", "aggregateType": "work_unit", "payloadRequired": ["evidenceIds", "verdict"] },
+    { "eventType": "evidence.verification.recorded", "aggregateType": "evidence", "payloadRequired": ["missionId", "criterionId", "verdict", "integrityHash"] }
+  ]
+}

--- a/platform/contracts/v1/event-envelope.schema.json
+++ b/platform/contracts/v1/event-envelope.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.agenthub.dev/v1/event-envelope.schema.json",
+  "title": "Mission event envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "aggregate_type", "aggregate_id", "sequence", "event_type",
+    "actor", "occurred_at", "correlation_id", "payload", "schema_version"
+  ],
+  "properties": {
+    "event_id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "aggregate_type": {
+      "type": "string",
+      "enum": ["mission", "mission_contract", "work_unit", "evidence"]
+    },
+    "aggregate_id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "sequence": { "type": "integer", "minimum": 1 },
+    "event_type": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*){2,}$"
+    },
+    "actor": { "$ref": "common.schema.json#/$defs/actorRef" },
+    "occurred_at": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "correlation_id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "causation_id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "payload": { "type": "object" },
+    "schema_version": { "const": 1 }
+  }
+}

--- a/platform/contracts/v1/evidence.schema.json
+++ b/platform/contracts/v1/evidence.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.agenthub.dev/v1/evidence.schema.json",
+  "title": "Evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id", "missionId", "criterionId", "verifier", "verdict", "artifactRefs",
+    "summary", "generatedAt", "integrityHash"
+  ],
+  "properties": {
+    "id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "missionId": { "$ref": "common.schema.json#/$defs/identifier" },
+    "workUnitId": { "$ref": "common.schema.json#/$defs/identifier" },
+    "criterionId": { "$ref": "common.schema.json#/$defs/identifier" },
+    "verifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": { "$ref": "common.schema.json#/$defs/identifier" },
+        "version": { "type": "string", "minLength": 1, "maxLength": 255 },
+        "configurationDigest": {
+          "type": "string",
+          "pattern": "^sha256:[a-fA-F0-9]{64}$"
+        }
+      }
+    },
+    "verdict": { "type": "string", "enum": ["PASS", "FAIL", "INCONCLUSIVE"] },
+    "artifactRefs": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/artifactRef" }
+    },
+    "summary": { "type": "string", "minLength": 1, "maxLength": 10000 },
+    "generatedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "integrityHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-fA-F0-9]{64}$"
+    }
+  }
+}

--- a/platform/contracts/v1/mission-contract.schema.json
+++ b/platform/contracts/v1/mission-contract.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.agenthub.dev/v1/mission-contract.schema.json",
+  "title": "Mission contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id", "version", "repositoryScopes", "allowedCapabilities", "budgets",
+    "acceptanceCriteria", "decisionGates", "forbiddenActions"
+  ],
+  "properties": {
+    "id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "version": { "type": "integer", "minimum": 1 },
+    "repositoryScopes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repository", "baseRef", "paths"],
+        "properties": {
+          "repository": { "type": "string", "minLength": 1, "maxLength": 2048 },
+          "baseRef": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "paths": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1, "maxLength": 1024 }
+          },
+          "write": { "type": "boolean", "default": true }
+        }
+      }
+    },
+    "allowedCapabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["capability"],
+        "properties": {
+          "capability": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "scope": { "type": "object", "additionalProperties": true }
+        }
+      }
+    },
+    "budgets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["timeSeconds", "modelCost", "retries"],
+      "properties": {
+        "timeSeconds": { "type": "integer", "minimum": 1 },
+        "modelCost": { "type": "number", "minimum": 0 },
+        "retries": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "acceptanceCriteria": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "kind", "description", "required"],
+        "properties": {
+          "id": { "$ref": "common.schema.json#/$defs/identifier" },
+          "kind": {
+            "type": "string",
+            "enum": ["command", "test", "build", "security", "contract", "manual"]
+          },
+          "description": { "type": "string", "minLength": 1, "maxLength": 2000 },
+          "required": { "type": "boolean" },
+          "configuration": { "type": "object", "additionalProperties": true }
+        }
+      }
+    },
+    "decisionGates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "trigger"],
+        "properties": {
+          "id": { "$ref": "common.schema.json#/$defs/identifier" },
+          "trigger": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "blocking": { "type": "boolean", "default": true }
+        }
+      }
+    },
+    "forbiddenActions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1, "maxLength": 255 }
+    },
+    "expiresAt": { "$ref": "common.schema.json#/$defs/timestamp" }
+  }
+}

--- a/platform/contracts/v1/mission.schema.json
+++ b/platform/contracts/v1/mission.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.agenthub.dev/v1/mission.schema.json",
+  "title": "Mission",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id", "workspaceId", "title", "objective", "source", "contractId",
+    "status", "planVersion", "createdBy", "createdAt", "updatedAt"
+  ],
+  "properties": {
+    "id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "workspaceId": { "$ref": "common.schema.json#/$defs/identifier" },
+    "title": { "type": "string", "minLength": 1, "maxLength": 255 },
+    "objective": { "type": "string", "minLength": 1, "maxLength": 10000 },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["manual", "issue", "api", "import"] },
+        "reference": { "type": "string", "maxLength": 2048 },
+        "externalId": { "type": "string", "maxLength": 255 }
+      }
+    },
+    "contractId": { "$ref": "common.schema.json#/$defs/identifier" },
+    "status": {
+      "type": "string",
+      "enum": [
+        "DRAFT", "READY", "RUNNING", "VERIFYING", "WAITING_DECISION",
+        "SUCCEEDED", "FAILED", "CANCELLED"
+      ]
+    },
+    "planVersion": { "type": "integer", "minimum": 0 },
+    "createdBy": { "$ref": "common.schema.json#/$defs/actorRef" },
+    "createdAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "updatedAt": { "$ref": "common.schema.json#/$defs/timestamp" }
+  }
+}

--- a/platform/contracts/v1/work-unit.schema.json
+++ b/platform/contracts/v1/work-unit.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.agenthub.dev/v1/work-unit.schema.json",
+  "title": "Work unit",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id", "missionId", "kind", "dependencies", "inputRefs", "expectedOutputs",
+    "requiredCapabilities", "status", "attempt"
+  ],
+  "properties": {
+    "id": { "$ref": "common.schema.json#/$defs/identifier" },
+    "missionId": { "$ref": "common.schema.json#/$defs/identifier" },
+    "kind": { "type": "string", "minLength": 1, "maxLength": 255 },
+    "dependencies": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "common.schema.json#/$defs/identifier" }
+    },
+    "inputRefs": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/artifactRef" }
+    },
+    "expectedOutputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "required"],
+        "properties": {
+          "kind": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "required": { "type": "boolean" }
+        }
+      }
+    },
+    "requiredCapabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1, "maxLength": 255 }
+    },
+    "assignedAdapter": { "type": "string", "minLength": 1, "maxLength": 255 },
+    "status": {
+      "type": "string",
+      "enum": [
+        "PENDING", "LEASED", "RUNNING", "VERIFYING", "WAITING",
+        "RETRYING", "SUCCEEDED", "FAILED", "CANCELLED"
+      ]
+    },
+    "attempt": { "type": "integer", "minimum": 0 },
+    "lease": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "runnerId", "expiresAt"],
+      "properties": {
+        "id": { "$ref": "common.schema.json#/$defs/identifier" },
+        "runnerId": { "$ref": "common.schema.json#/$defs/identifier" },
+        "expiresAt": { "$ref": "common.schema.json#/$defs/timestamp" }
+      }
+    }
+  }
+}

--- a/tests/contracts/requirements.txt
+++ b/tests/contracts/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==4.25.0

--- a/tests/contracts/test_v1_contracts.py
+++ b/tests/contracts/test_v1_contracts.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+
+CONTRACT_DIR = Path(__file__).parents[2] / "platform" / "contracts" / "v1"
+
+
+class PublicContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.documents = {
+            path.name: json.loads(path.read_text(encoding="utf-8"))
+            for path in CONTRACT_DIR.glob("*.json")
+        }
+        resources = [
+            (document["$id"], Resource.from_contents(document))
+            for document in cls.documents.values()
+            if "$id" in document
+        ]
+        cls.registry = Registry().with_resources(resources)
+
+    def test_all_schemas_are_valid_draft_2020_12(self) -> None:
+        schema_names = {name for name in self.documents if name.endswith(".schema.json")}
+        self.assertEqual(
+            schema_names,
+            {
+                "common.schema.json",
+                "mission.schema.json",
+                "mission-contract.schema.json",
+                "work-unit.schema.json",
+                "evidence.schema.json",
+                "event-envelope.schema.json",
+            },
+        )
+        for name in schema_names:
+            with self.subTest(schema=name):
+                Draft202012Validator.check_schema(self.documents[name])
+
+    def test_schema_identifiers_are_unique_and_versioned(self) -> None:
+        identifiers = [
+            document["$id"] for document in self.documents.values() if "$id" in document
+        ]
+        self.assertEqual(len(identifiers), len(set(identifiers)))
+        self.assertTrue(all("/v1/" in identifier for identifier in identifiers))
+
+    def test_representative_documents_validate(self) -> None:
+        digest = "sha256:" + "a" * 64
+        actor = {"type": "human", "id": "user-1"}
+        timestamp = "2026-08-01T00:00:00Z"
+        examples = {
+            "mission.schema.json": {
+                "id": "mis-1",
+                "workspaceId": "workspace-1",
+                "title": "Fix issue 42",
+                "objective": "Produce a tested, reviewable pull request.",
+                "source": {"type": "issue", "reference": "https://example.test/issues/42"},
+                "contractId": "contract-1",
+                "status": "READY",
+                "planVersion": 0,
+                "createdBy": actor,
+                "createdAt": timestamp,
+                "updatedAt": timestamp,
+            },
+            "mission-contract.schema.json": {
+                "id": "contract-1",
+                "version": 1,
+                "repositoryScopes": [
+                    {"repository": "owner/repo", "baseRef": "main", "paths": ["app/**"]}
+                ],
+                "allowedCapabilities": [{"capability": "repository.write"}],
+                "budgets": {"timeSeconds": 3600, "modelCost": 10, "retries": 2},
+                "acceptanceCriteria": [
+                    {"id": "tests", "kind": "test", "description": "Tests pass", "required": True}
+                ],
+                "decisionGates": [],
+                "forbiddenActions": ["repository.force_push"],
+            },
+            "work-unit.schema.json": {
+                "id": "wu-1",
+                "missionId": "mis-1",
+                "kind": "code_change",
+                "dependencies": [],
+                "inputRefs": [],
+                "expectedOutputs": [{"kind": "diff", "required": True}],
+                "requiredCapabilities": ["repository.write"],
+                "status": "PENDING",
+                "attempt": 0,
+            },
+            "evidence.schema.json": {
+                "id": "evd-1",
+                "missionId": "mis-1",
+                "criterionId": "tests",
+                "verifier": {"id": "pytest", "version": "9.0"},
+                "verdict": "PASS",
+                "artifactRefs": [{"id": "artifact-1", "digest": digest}],
+                "summary": "All required tests passed.",
+                "generatedAt": timestamp,
+                "integrityHash": digest,
+            },
+            "event-envelope.schema.json": {
+                "event_id": "evt-1",
+                "aggregate_type": "work_unit",
+                "aggregate_id": "wu-1",
+                "sequence": 1,
+                "event_type": "work_unit.execution.started",
+                "actor": {"type": "runner", "id": "runner-1"},
+                "occurred_at": timestamp,
+                "correlation_id": "mis-1",
+                "payload": {"attempt": 1},
+                "schema_version": 1,
+            },
+        }
+        for schema_name, instance in examples.items():
+            with self.subTest(schema=schema_name):
+                Draft202012Validator(
+                    self.documents[schema_name], registry=self.registry
+                ).validate(instance)
+
+    def test_event_catalog_is_unique_and_matches_envelope_aggregates(self) -> None:
+        catalog = self.documents["event-catalog.json"]
+        self.assertEqual(catalog["catalogVersion"], 1)
+        event_types = [event["eventType"] for event in catalog["events"]]
+        self.assertEqual(len(event_types), len(set(event_types)))
+
+        allowed_aggregates = set(
+            self.documents["event-envelope.schema.json"]["properties"]["aggregate_type"]["enum"]
+        )
+        for event in catalog["events"]:
+            with self.subTest(event=event["eventType"]):
+                self.assertIn(event["aggregateType"], allowed_aggregates)
+                self.assertRegex(event["eventType"], r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2,}$")
+                self.assertEqual(len(event["payloadRequired"]), len(set(event["payloadRequired"])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What changed: adds versioned JSON Schemas for Mission, MissionContract, WorkUnit, Evidence, and the mission event envelope; adds the authoritative v1 event catalog, contract tests, and a focused GitHub Actions workflow. Why: Stage 0 needs a stable language-neutral boundary before backend models, compatibility mappings, runners, and adapters are implemented. Impact: no existing runtime path changes; future components can now build against validated v1 contracts. Validation: 4 contract tests pass locally and the staged diff passes git diff --check.